### PR TITLE
Provide a better entrypoint.sh to allow only passing flags to CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM debian:jessie
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r memcache && useradd -r -g memcache memcache
 
-RUN apt-get update && apt-get install -y libevent-2.0-5 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libevent-2.0-5 \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENV MEMCACHED_VERSION 1.4.24
 ENV MEMCACHED_SHA1 32a798a37ef782da10a09d74aa1e5be91f2861db
@@ -24,7 +26,9 @@ RUN buildDeps='curl gcc libc6-dev libevent-dev make perl' \
 	&& cd / && rm -rf /usr/src/memcached \
 	&& apt-get purge -y --auto-remove $buildDeps
 
-EXPOSE 11211
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 USER memcache
+EXPOSE 11211
 CMD ["memcached"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# first check if we're passing flags, if so
+# prepend with memcached
+if [ "${1:0:1}" = '-' ]; then
+    set -- memcached "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
This allows a simpler CMD execution by only requiring to pass flags to `docker run`.

Prior to this, the execution would look like:

```
$ docker run --rm -it memcached memcached -m 64
```

This patch shortens to:

```
$ docker run --rm -it memcached -m 64
```

and avoids the redundant `memcached memcached` overspecification.