### PR TITLE
Use "dpkg-architecture" to ensure the _image_ (not the host CPU) architecture gets built properly

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,6 +8,8 @@ ENV MEMCACHED_SHA1 7c7214f5183c6e20c22b243e21ed1ffddb91497e
 
 RUN set -x \
 	&& apk add --no-cache --virtual .build-deps \
+		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		libc-dev \
 		libevent-dev \
@@ -21,8 +23,8 @@ RUN set -x \
 	&& tar -xzf memcached.tar.gz -C /usr/src/memcached --strip-components=1 \
 	&& rm memcached.tar.gz \
 	&& cd /usr/src/memcached \
-	&& ./configure \
-	&& make -j$(getconf _NPROCESSORS_ONLN) \
+	&& ./configure --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& cd / && rm -rf /usr/src/memcached \
 	&& runDeps="$( \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV MEMCACHED_VERSION 1.4.34
 ENV MEMCACHED_SHA1 7c7214f5183c6e20c22b243e21ed1ffddb91497e
 
-RUN buildDeps=' \
+RUN set -x \
+	&& buildDeps=' \
+		dpkg-dev \
 		gcc \
 		libc6-dev \
 		libevent-dev \
@@ -18,7 +20,6 @@ RUN buildDeps=' \
 		perl \
 		wget \
 	' \
-	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& wget -O memcached.tar.gz "http://memcached.org/files/memcached-$MEMCACHED_VERSION.tar.gz" \
@@ -27,8 +28,8 @@ RUN buildDeps=' \
 	&& tar -xzf memcached.tar.gz -C /usr/src/memcached --strip-components=1 \
 	&& rm memcached.tar.gz \
 	&& cd /usr/src/memcached \
-	&& ./configure \
-	&& make -j$(nproc) \
+	&& ./configure --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& cd / && rm -rf /usr/src/memcached \
 	&& apt-get purge -y --auto-remove $buildDeps


### PR DESCRIPTION
This is meant as a proper multiarch test, essentially -- for `amd64`, this has net zero effect.

Nobody has noticed up until now that `i386/memcached` actually contains 64bit binaries. :innocent: