### PR TITLE
Add "travis_retry" to our build to reduce transitory failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - image="memcached:$VARIANT"
 
 script:
-  - docker build -t "$image" "$VARIANT"
+  - travis_retry docker build -t "$image" "$VARIANT"
   - ~/official-images/test/run.sh "$image"
 
 after_script:


### PR DESCRIPTION
I was about to commit this change to all our repos and figured I should probably test it on one first to make sure it's actually working properly. :innocent: