### PR TITLE
Use numeric uid

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.7
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN adduser -D memcache
+RUN adduser -D -u 1000 memcache
 
 ENV MEMCACHED_VERSION 1.5.7
 ENV MEMCACHED_SHA1 31d6f6b80668025e4616aa2ad5c7a45f24ed9665
@@ -56,6 +56,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-USER memcache
+USER 1000
 EXPOSE 11211
 CMD ["memcached"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r memcache && useradd -r -g memcache memcache
+RUN groupadd -r -g 999 memcache && useradd -r -u 999 -g memcache memcache
 
 ENV MEMCACHED_VERSION 1.5.7
 ENV MEMCACHED_SHA1 31d6f6b80668025e4616aa2ad5c7a45f24ed9665
@@ -51,6 +51,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-USER memcache
+USER 999
 EXPOSE 11211
 CMD ["memcached"]


### PR DESCRIPTION
Fixes #36.

This also defines the uids to be the same as the current images. They are different across Debian and Alpine because the Alpine image creates a regular account (uid >=1000) whereas the Debian image creates a system account (uid <1000):
```
$ docker run --rm -it memcached id
uid=999(memcache) gid=999(memcache) groups=999(memcache)
$ docker run --rm -it memcached:alpine id
uid=1000(memcache) gid=1000(memcache)
```