### PR TITLE
Enable external storage shim (extstore).

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -22,6 +22,7 @@ RUN set -x \
 		perl \
 		perl-utils \
 		tar \
+		wget \
 	\
 	&& wget -O memcached.tar.gz "https://memcached.org/files/memcached-$MEMCACHED_VERSION.tar.gz" \
 	&& echo "$MEMCACHED_SHA1  memcached.tar.gz" | sha1sum -c - \
@@ -31,12 +32,22 @@ RUN set -x \
 	\
 	&& cd /usr/src/memcached \
 	\
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& enableExtstore="$( \
+# https://github.com/docker-library/memcached/pull/38
+		case "$gnuArch" in \
+# https://github.com/memcached/memcached/issues/381 "--enable-extstore on s390x (IBM System Z mainframe architecture) fails tests"
+			s390x-*) ;; \
+			*) echo '--enable-extstore' ;; \
+		esac \
+	)" \
 	&& ./configure \
-		--build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-		--enable-extstore \
+		--build="$gnuArch" \
 		--enable-sasl \
+		$enableExtstore \
 	&& make -j "$(nproc)" \
 	\
+# TODO https://github.com/memcached/memcached/issues/382 "t/chunked-extstore.t is flaky on arm32v6"
 	&& make test \
 	&& make install \
 	\

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -33,6 +33,7 @@ RUN set -x \
 	\
 	&& ./configure \
 		--build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+		--enable-extstore \
 		--enable-sasl \
 	&& make -j "$(nproc)" \
 	\

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -32,6 +32,7 @@ RUN set -x \
 	\
 	&& ./configure \
 		--build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+		--enable-extstore \
 		--enable-sasl \
 	&& make -j "$(nproc)" \
 	\

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -30,12 +30,22 @@ RUN set -x \
 	\
 	&& cd /usr/src/memcached \
 	\
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& enableExtstore="$( \
+# https://github.com/docker-library/memcached/pull/38
+		case "$gnuArch" in \
+# https://github.com/memcached/memcached/issues/381 "--enable-extstore on s390x (IBM System Z mainframe architecture) fails tests"
+			s390x-*) ;; \
+			*) echo '--enable-extstore' ;; \
+		esac \
+	)" \
 	&& ./configure \
-		--build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-		--enable-extstore \
+		--build="$gnuArch" \
 		--enable-sasl \
+		$enableExtstore \
 	&& make -j "$(nproc)" \
 	\
+# TODO https://github.com/memcached/memcached/issues/382 "t/chunked-extstore.t is flaky on arm32v6"
 	&& make test \
 	&& make install \
 	\


### PR DESCRIPTION
Extstore info at: https://github.com/memcached/memcached/wiki/Extstore

Looks like it is maturing very quickly and would be worthwhile having access to it on Docker images.