### PR TITLE
Update adduser/useradd to use hard-coded UID of 11211

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN adduser -D memcache
+RUN addgroup -g 11211 memcache && adduser -D -u 11211 -G memcache memcache
 
 ENV MEMCACHED_VERSION 1.5.10
 ENV MEMCACHED_SHA1 fff9351b360a09497cd805d3e4c1ffbe860d067d

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r memcache && useradd -r -g memcache memcache
+RUN groupadd --system --gid 11211 memcache && useradd --system --gid memcache --uid 11211 memcache
 
 ENV MEMCACHED_VERSION 1.5.10
 ENV MEMCACHED_SHA1 fff9351b360a09497cd805d3e4c1ffbe860d067d


### PR DESCRIPTION
This is splitting off the uncontested change from #37, also updating both instances to be the same and to use the memcached port number (because we can).

We don't have a `VOLUME`, and memcached has no notion of persistance that I'm aware of (https://github.com/memcached/memcached/issues/370, https://github.com/memcached/memcached/pull/342), so user impact here should be nonexistent.