### PR TITLE
Update to 1.5.13

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.9
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN addgroup -g 11211 memcache && adduser -D -u 11211 -G memcache memcache
 
-ENV MEMCACHED_VERSION 1.5.12
-ENV MEMCACHED_SHA1 f67096ba64b0c47668bcad5b680010c4f8987d4c
+ENV MEMCACHED_VERSION 1.5.13
+ENV MEMCACHED_SHA1 f0ddd566a55fdc5397d458cf3b3806b5cb48bb18
 
 RUN set -x \
 	\
@@ -31,6 +31,11 @@ RUN set -x \
 	&& rm memcached.tar.gz \
 	\
 	&& cd /usr/src/memcached \
+	\
+# https://github.com/memcached/memcached/pull/480 (hopefully to be removed in 1.5.14)
+	&& wget -O wait_ext_flush.patch 'https://github.com/memcached/memcached/pull/480.patch' \
+	&& patch -p1 -i wait_ext_flush.patch \
+	&& rm wait_ext_flush.patch \
 	\
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& enableExtstore="$( \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -3,8 +3,8 @@ FROM debian:stretch-slim
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd --system --gid 11211 memcache && useradd --system --gid memcache --uid 11211 memcache
 
-ENV MEMCACHED_VERSION 1.5.12
-ENV MEMCACHED_SHA1 f67096ba64b0c47668bcad5b680010c4f8987d4c
+ENV MEMCACHED_VERSION 1.5.13
+ENV MEMCACHED_SHA1 f0ddd566a55fdc5397d458cf3b3806b5cb48bb18
 
 RUN set -x \
 	\
@@ -29,6 +29,11 @@ RUN set -x \
 	&& rm memcached.tar.gz \
 	\
 	&& cd /usr/src/memcached \
+	\
+# https://github.com/memcached/memcached/pull/480 (hopefully to be removed in 1.5.14)
+	&& wget -O wait_ext_flush.patch 'https://github.com/memcached/memcached/pull/480.patch' \
+	&& patch -p1 --input=wait_ext_flush.patch \
+	&& rm wait_ext_flush.patch \
 	\
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& enableExtstore="$( \


### PR DESCRIPTION
This also (hopefully temporarily) applies https://github.com/memcached/memcached/pull/480 in order to get past the test failure:

    Undefined subroutine &main::wait_ext_flush called at t/extstore-jbod.t line 42.
    t/extstore-jbod.t ...........
    Dubious, test returned 29 (wstat 7424, 0x1d00)
    No subtests run

@dormando do you think this is reasonable for us to be able to get 1.5.13 out, or would you prefer we just wait for 1.5.14?