### PR TITLE
Add SASL password file support with PLAIN mechanism

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -44,6 +44,7 @@ RUN set -x \
 	&& ./configure \
 		--build="$gnuArch" \
 		--enable-sasl \
+		--enable-sasl-pwdb \
 		$enableExtstore \
 	&& make -j "$(nproc)" \
 	\
@@ -59,7 +60,7 @@ RUN set -x \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
-	&& apk add --virtual .memcached-rundeps $runDeps \
+	&& apk add --virtual .memcached-rundeps $runDeps cyrus-sasl-plain \
 	&& apk del .build-deps \
 	\
 	&& memcached -V

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,6 +3,9 @@ FROM alpine:3.9
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN addgroup -g 11211 memcache && adduser -D -u 11211 -G memcache memcache
 
+# ensure SASL's "libplain.so" is installed as per https://github.com/memcached/memcached/wiki/SASLHowto
+RUN apk add --no-cache cyrus-sasl-plain
+
 ENV MEMCACHED_VERSION 1.5.16
 ENV MEMCACHED_SHA1 06a9661638cb20232d0ccea088f52ca10b959968
 
@@ -60,7 +63,7 @@ RUN set -x \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
-	&& apk add --virtual .memcached-rundeps $runDeps cyrus-sasl-plain \
+	&& apk add --virtual .memcached-rundeps $runDeps \
 	&& apk del .build-deps \
 	\
 	&& memcached -V

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -3,12 +3,22 @@ FROM debian:stretch-slim
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd --system --gid 11211 memcache && useradd --system --gid memcache --uid 11211 memcache
 
+# ensure SASL's "libplain.so" is installed as per https://github.com/memcached/memcached/wiki/SASLHowto
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libsasl2-modules \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV MEMCACHED_VERSION 1.5.16
 ENV MEMCACHED_SHA1 06a9661638cb20232d0ccea088f52ca10b959968
 
 RUN set -x \
 	\
-	&& buildDeps=' \
+	&& savedAptMark="$(apt-mark showmanual)" \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
 		ca-certificates \
 		dpkg-dev \
 		gcc \
@@ -18,8 +28,6 @@ RUN set -x \
 		make \
 		perl \
 		wget \
-	' \
-	&& apt-get update && apt-get install -y $buildDeps libsasl2-modules --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
 	&& wget -O memcached.tar.gz "https://memcached.org/files/memcached-$MEMCACHED_VERSION.tar.gz" \
@@ -52,10 +60,16 @@ RUN set -x \
 	\
 	&& cd / && rm -rf /usr/src/memcached \
 	\
-	&& apt-mark manual \
-		libevent-2.0-5 \
-		libsasl2-2 \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-mark auto '.*' > /dev/null \
+	&& apt-mark manual $savedAptMark > /dev/null \
+	&& find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 	\
 	&& memcached -V
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -19,7 +19,7 @@ RUN set -x \
 		perl \
 		wget \
 	' \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& apt-get update && apt-get install -y $buildDeps libsasl2-modules --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
 	&& wget -O memcached.tar.gz "https://memcached.org/files/memcached-$MEMCACHED_VERSION.tar.gz" \
@@ -42,6 +42,7 @@ RUN set -x \
 	&& ./configure \
 		--build="$gnuArch" \
 		--enable-sasl \
+		--enable-sasl-pwdb \
 		$enableExtstore \
 	&& make -j "$(nproc)" \
 	\


### PR DESCRIPTION
During testing out SASL support I noticed there are no libraries for user auth in the image (e.g. `PLAIN`, `LOGIN`, `CRAM-MD5`, `DIGEST-MD5`). Hence the `--enable-sasl` flag only allows you to run memcached with `-S` and fails to list mechanisms during auth. Since most memcached clients only support`PLAIN` I've added this to alpine and all auth modules (including `PLAIN`) to debian (mentioned here https://github.com/memcached/memcached/wiki/SASLHowto).

By adding the `--enable-sasl-pwdb` flag you can accomplish server side auth in a simplified manner. By creating a plaintext file with `username:password` and pointing to it from `MEMCACHED_SASL_PWDB` variable you can skip the step to generate a password file with `saslpasswd2` (https://github.com/memcached/memcached/wiki/ReleaseNotes145#sasl_pwdb-for-more-simple-auth-deployments).

Both these changes should satisfy the general use case of an optional auth layer on top of memcached.