### PR TITLE
Add TLS support

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -22,6 +22,7 @@ RUN set -x \
 		linux-headers \
 		make \
 		openssl \
+		openssl-dev \
 		perl \
 		perl-utils \
 		tar \
@@ -48,7 +49,10 @@ RUN set -x \
 		--build="$gnuArch" \
 		--enable-sasl \
 		--enable-sasl-pwdb \
+		--enable-tls \
 		$enableExtstore \
+# while https://github.com/memcached/memcached/issues/572 hasn't merge
+	&& sed -i "s/assert(c->thread->thread_id == (unsigned long)pthread_self());/assert(pthread_equal(c->thread->thread_id, pthread_self()) != 0);/g" tls.c \
 	&& make -j "$(nproc)" \
 	\
 # TODO https://github.com/memcached/memcached/issues/382 "t/chunked-extstore.t is flaky on arm32v6"

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -22,7 +22,6 @@ RUN set -x \
 		linux-headers \
 		make \
 		openssl \
-		openssl-dev \
 		perl \
 		perl-utils \
 		tar \
@@ -49,10 +48,7 @@ RUN set -x \
 		--build="$gnuArch" \
 		--enable-sasl \
 		--enable-sasl-pwdb \
-		--enable-tls \
 		$enableExtstore \
-# while https://github.com/memcached/memcached/issues/572 hasn't merge
-	&& sed -i "s/assert(c->thread->thread_id == (unsigned long)pthread_self());/assert(pthread_equal(c->thread->thread_id, pthread_self()) != 0);/g" tls.c \
 	&& make -j "$(nproc)" \
 	\
 # TODO https://github.com/memcached/memcached/issues/382 "t/chunked-extstore.t is flaky on arm32v6"

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -23,9 +23,10 @@ RUN set -x \
 		dpkg-dev \
 		gcc \
 		libc6-dev \
-		libssl-dev \
 		libevent-dev \
+		libio-socket-ssl-perl \
 		libsasl2-dev \
+		libssl-dev \
 		make \
 		perl \
 		wget \
@@ -56,8 +57,11 @@ RUN set -x \
 		$enableExtstore \
 	&& make -j "$(nproc)" \
 	\
+# see https://github.com/docker-library/memcached/pull/54#issuecomment-562797748 and https://bugs.debian.org/927461 for why we have to munge openssl.cnf
+	&& sed -i.bak 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf \
 # TODO https://github.com/memcached/memcached/issues/382 "t/chunked-extstore.t is flaky on arm32v6"
 	&& make test \
+	&& mv /etc/ssl/openssl.cnf.bak /etc/ssl/openssl.cnf \
 	&& make install \
 	\
 	&& cd / && rm -rf /usr/src/memcached \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -23,6 +23,7 @@ RUN set -x \
 		dpkg-dev \
 		gcc \
 		libc6-dev \
+		libssl-dev \
 		libevent-dev \
 		libsasl2-dev \
 		make \
@@ -51,6 +52,7 @@ RUN set -x \
 		--build="$gnuArch" \
 		--enable-sasl \
 		--enable-sasl-pwdb \
+		--enable-tls \
 		$enableExtstore \
 	&& make -j "$(nproc)" \
 	\


### PR DESCRIPTION
Memcached support TLS connections since version 1.5.13[0] which needs an extra build option.

[0] https://github.com/memcached/memcached/wiki/TLS