### PR TITLE
Add "PARALLEL" to "make test" invocation

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -52,10 +52,11 @@ RUN set -x \
 		--enable-sasl-pwdb \
 		--enable-tls \
 		$enableExtstore \
-	&& make -j "$(nproc)" \
+	&& nproc="$(nproc)" \
+	&& make -j "$nproc" \
 	\
-# TODO https://github.com/memcached/memcached/issues/382 "t/chunked-extstore.t is flaky on arm32v6"
-	&& make test \
+	&& make test PARALLEL="$nproc" \
+	\
 	&& make install \
 	\
 	&& cd / && rm -rf /usr/src/memcached \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -55,13 +55,14 @@ RUN set -x \
 		--enable-sasl-pwdb \
 		--enable-tls \
 		$enableExtstore \
-	&& make -j "$(nproc)" \
+	&& nproc="$(nproc)" \
+	&& make -j "$nproc" \
 	\
 # see https://github.com/docker-library/memcached/pull/54#issuecomment-562797748 and https://bugs.debian.org/927461 for why we have to munge openssl.cnf
 	&& sed -i.bak 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf \
-# TODO https://github.com/memcached/memcached/issues/382 "t/chunked-extstore.t is flaky on arm32v6"
-	&& make test \
+	&& make test PARALLEL="$nproc" \
 	&& mv /etc/ssl/openssl.cnf.bak /etc/ssl/openssl.cnf \
+	\
 	&& make install \
 	\
 	&& cd / && rm -rf /usr/src/memcached \


### PR DESCRIPTION
This should improve the overall build time on servers where we have multiple cores (especially for some of [those upstream tests that end up having to sleep for long periods of time](https://github.com/memcached/memcached/commit/c0a2da219d6ae9477ee31e9214b3d973d26b5783)).