### PR TITLE
feat: define user id and group instead of name in the Dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -64,6 +64,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-USER memcache
+USER 11211:11211
 EXPOSE 11211
 CMD ["memcached"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -84,6 +84,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-USER memcache
+USER 11211:11211
 EXPOSE 11211
 CMD ["memcached"]


### PR DESCRIPTION
## Description
Define user id and group instead of name in the Dockerfile
Note that the entry point will set the username. 

## Motivation

Be able to use this image in Pods qualified with security context restricted in Kubernetes and Opensift clusters.  

TL'DR:
- In a k8s cluster if we try to run a Pod/Container with this image as restricted without informing `RunAsUser` we will face the error: `"container has runAsNonRoot and image will run as root …`
- Then, if we try to use this image in Openshift in the same circumstances we will check:
`Error: container has runAsNonRoot and image has non-numeric user (memcache), cannot verify user is non-root` Therefore, for a Pod/Container to be qualified to the restricted-v2 SCC (the most restricted context) we cannot use RunAsUser. 

NOTE: It was checked locally with the command `memcached -m 1024 -o modern -v` and all worked fine. 