### PR TITLE
Upgrade zlibg package in the distro

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -6,6 +6,7 @@ RUN groupadd --system --gid 11211 memcache && useradd --system --gid memcache --
 # ensure SASL's "libplain.so" is installed as per https://github.com/memcached/memcached/wiki/SASLHowto
 RUN set -eux; \
 	apt-get update; \
+    apt-get upgrade; \
 	apt-get install -y --no-install-recommends \
 		libsasl2-modules \
 	; \


### PR DESCRIPTION
### Description
Add `apt-get upgrade` just after `update` command in order to upgrade distro

### Context

I'm using trivy to scan vulnerabilities in my docker images. Using the official `memcached` image, it throws that it is vulnerable to **CVE-2022-37434 **: 
```
│ zlib1g       │ CVE-2022-37434 │          │ 1:1.2.11.dfsg-2+deb11u1 │ 1:1.2.11.dfsg-2+deb11u2 │ zlib: a heap-based buffer over-read or buffer overflow in   │
│              │                │          │                         │                         │ inflate in inflate.c...                                     │
│              │                │          │                         │                         │ https://avd.aquasec.com/nvd/cve-2022-37434                  │
└──────────────┴────────────────┴──────────┴─────────────────────────┴─────────────────────────┴─────────────────────────────────────────────────────────────┘
```

The image is based on `debian:bullseye-slim`, and just an upgrade at the beginning did the trick:

```
:: ~ » docker exec -it 64cddf7bd8c3f438ba749855a3e43f359e45e7dec46ef625d4b27c11037bacae /bin/sh
# apt-get update
Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB]
Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]
Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8182 kB]
Get:5 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [182 kB]
Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [2596 B]
Fetched 8574 kB in 2s (4318 kB/s)
Reading package lists... Done
# apt-get upgrade
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Calculating upgrade... Done
The following packages will be upgraded:
  zlib1g
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 91.4 kB of archives.
After this operation, 1024 B of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://deb.debian.org/debian-security bullseye-security/main amd64 zlib1g amd64 1:1.2.11.dfsg-2+deb11u2 [91.4 kB]
Fetched 91.4 kB in 0s (2191 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
(Reading database ... 6661 files and directories currently installed.)
Preparing to unpack .../zlib1g_1%3a1.2.11.dfsg-2+deb11u2_amd64.deb ...
Unpacking zlib1g:amd64 (1:1.2.11.dfsg-2+deb11u2) over (1:1.2.11.dfsg-2+deb11u1) ...
Setting up zlib1g:amd64 (1:1.2.11.dfsg-2+deb11u2) ...
Processing triggers for libc-bin (2.31-13+deb11u3) ... 
```