### PR TITLE
Use numeric user id to pass runAsNonRoot on Kubernetes

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -131,6 +131,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-USER memcache
+# USER memcache
+USER 11211
 EXPOSE 11211
 CMD ["memcached"]


### PR DESCRIPTION
Without this, we have:

```
container has runAsNonRoot and image has non-numeric user (memcache), cannot verify user is non-root
```