### PR TITLE
Enable built-in proxy support

### DIFF
--- a/1/alpine/Dockerfile
+++ b/1/alpine/Dockerfile
@@ -35,6 +35,8 @@ RUN set -eux; \
 		perl \
 		perl-io-socket-ssl \
 		perl-utils \
+# temporary, see below
+		patch \
 	; \
 	\
 	wget -O memcached.tar.gz "$MEMCACHED_URL"; \
@@ -43,12 +45,20 @@ RUN set -eux; \
 	tar -xzf memcached.tar.gz -C /usr/src/memcached --strip-components=1; \
 	rm memcached.tar.gz; \
 	\
+# https://github.com/memcached/memcached/issues/1220
+# https://github.com/memcached/memcached/pull/1221
+	wget -O memcached-time-overflow.patch 'https://github.com/tianon/memcached/commit/8d4e02984661a3a26decc5a45d62a9eeaaf72986.patch?full_index=1'; \
+	echo '59f068d1fe4819ec65ec8c7adc8c5ecf8a7753ba5c6e5a17e5ba42c9946074a2 *memcached-time-overflow.patch' | sha256sum -c -; \
+	patch --input="$PWD/memcached-time-overflow.patch" --strip=1 --directory=/usr/src/memcached; \
+	rm memcached-time-overflow.patch; \
+	\
 	cd /usr/src/memcached; \
 	\
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-extstore \
+		--enable-proxy \
 		--enable-sasl \
 		--enable-sasl-pwdb \
 		--enable-tls \

--- a/1/debian/Dockerfile
+++ b/1/debian/Dockerfile
@@ -48,12 +48,20 @@ RUN set -eux; \
 	tar -xzf memcached.tar.gz -C /usr/src/memcached --strip-components=1; \
 	rm memcached.tar.gz; \
 	\
+# https://github.com/memcached/memcached/issues/1220
+# https://github.com/memcached/memcached/pull/1221
+	wget -O memcached-time-overflow.patch 'https://github.com/tianon/memcached/commit/8d4e02984661a3a26decc5a45d62a9eeaaf72986.patch?full_index=1'; \
+	echo '59f068d1fe4819ec65ec8c7adc8c5ecf8a7753ba5c6e5a17e5ba42c9946074a2 *memcached-time-overflow.patch' | sha256sum -c -; \
+	patch --input="$PWD/memcached-time-overflow.patch" --strip=1 --directory=/usr/src/memcached; \
+	rm memcached-time-overflow.patch; \
+	\
 	cd /usr/src/memcached; \
 	\
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-extstore \
+		--enable-proxy \
 		--enable-sasl \
 		--enable-sasl-pwdb \
 		--enable-tls \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -49,6 +49,10 @@ RUN set -eux; \
 		perl \
 		perl-io-socket-ssl \
 		perl-utils \
+{{ if .version == "1.6.38" then ( -}}
+# temporary, see below
+		patch \
+{{ ) else "" end -}}
 	; \
 {{ ) else ( -}}
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -75,12 +79,22 @@ RUN set -eux; \
 	tar -xzf memcached.tar.gz -C /usr/src/memcached --strip-components=1; \
 	rm memcached.tar.gz; \
 	\
+{{ if .version == "1.6.38" then ( -}}
+# https://github.com/memcached/memcached/issues/1220
+# https://github.com/memcached/memcached/pull/1221
+	wget -O memcached-time-overflow.patch 'https://github.com/tianon/memcached/commit/8d4e02984661a3a26decc5a45d62a9eeaaf72986.patch?full_index=1'; \
+	echo '59f068d1fe4819ec65ec8c7adc8c5ecf8a7753ba5c6e5a17e5ba42c9946074a2 *memcached-time-overflow.patch' | sha256sum -c -; \
+	patch --input="$PWD/memcached-time-overflow.patch" --strip=1 --directory=/usr/src/memcached; \
+	rm memcached-time-overflow.patch; \
+	\
+{{ ) else "" end -}}
 	cd /usr/src/memcached; \
 	\
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-extstore \
+		--enable-proxy \
 		--enable-sasl \
 		--enable-sasl-pwdb \
 		--enable-tls \


### PR DESCRIPTION
Enables the built-in proxy feature, supported since version 1.6.23. More details: https://docs.memcached.org/features/proxy/