### PR TITLE
Try again in serial if tests fail in parallel

### DIFF
--- a/1/alpine/Dockerfile
+++ b/1/alpine/Dockerfile
@@ -66,7 +66,8 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 	make -j "$nproc"; \
 	\
-	make test PARALLEL="$nproc"; \
+# try the tests in parallel first, but many of them are resource-intensive, so fall back to serial
+	make test PARALLEL="$nproc" || make test; \
 	\
 	make install; \
 	\

--- a/1/debian/Dockerfile
+++ b/1/debian/Dockerfile
@@ -71,7 +71,8 @@ RUN set -eux; \
 	\
 # see https://github.com/docker-library/memcached/pull/54#issuecomment-562797748 and https://bugs.debian.org/927461 for why we have to munge openssl.cnf
 	sed -i.bak 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf; \
-	make test PARALLEL="$nproc"; \
+# try the tests in parallel first, but many of them are resource-intensive, so fall back to serial
+	make test PARALLEL="$nproc" || make test; \
 	mv /etc/ssl/openssl.cnf.bak /etc/ssl/openssl.cnf; \
 	\
 	make install; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -106,7 +106,8 @@ RUN set -eux; \
 # see https://github.com/docker-library/memcached/pull/54#issuecomment-562797748 and https://bugs.debian.org/927461 for why we have to munge openssl.cnf
 	sed -i.bak 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf; \
 {{ ) else "" end -}}
-	make test PARALLEL="$nproc"; \
+# try the tests in parallel first, but many of them are resource-intensive, so fall back to serial
+	make test PARALLEL="$nproc" || make test; \
 {{ if env.variant == "debian" then ( -}}
 	mv /etc/ssl/openssl.cnf.bak /etc/ssl/openssl.cnf; \
 {{ ) else "" end -}}


### PR DESCRIPTION
Many of the upstream tests are really resource intensive, so if they fail while running in parallel on a given host, chances are decent they'll pass in serial, so we should fall back once before we give up.

See https://github.com/memcached/memcached/issues/1220#issuecomment-2759662325 (and preceding discussion) -- there's a really decent chance this fixes our failing builds on `arm32v5` and `riscv64` (and we should re-enable `arm32v6` and `arm32v7` and give them a try again especially with this change, but that's a separate thing).