### PR TITLE
Force alignment on arm32

### DIFF
--- a/1/alpine/Dockerfile
+++ b/1/alpine/Dockerfile
@@ -55,6 +55,10 @@ RUN set -eux; \
 	cd /usr/src/memcached; \
 	\
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+# https://github.com/memcached/memcached/issues/1220#issuecomment-2770251664: on arm32, we need to override the upstream alignment check (which fails to detect the need for alignment on arm32v6+ on our hardware for some reason, which then causes us to fail the tests 😭)
+	case "$gnuArch" in \
+		arm-*abihf) export ac_cv_c_alignment=need ;; \
+	esac; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-extstore \

--- a/1/debian/Dockerfile
+++ b/1/debian/Dockerfile
@@ -58,6 +58,10 @@ RUN set -eux; \
 	cd /usr/src/memcached; \
 	\
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+# https://github.com/memcached/memcached/issues/1220#issuecomment-2770251664: on arm32, we need to override the upstream alignment check (which fails to detect the need for alignment on arm32v6+ on our hardware for some reason, which then causes us to fail the tests 😭)
+	case "$gnuArch" in \
+		arm-*abihf) export ac_cv_c_alignment=need ;; \
+	esac; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-extstore \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -91,6 +91,10 @@ RUN set -eux; \
 	cd /usr/src/memcached; \
 	\
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+# https://github.com/memcached/memcached/issues/1220#issuecomment-2770251664: on arm32, we need to override the upstream alignment check (which fails to detect the need for alignment on arm32v6+ on our hardware for some reason, which then causes us to fail the tests 😭)
+	case "$gnuArch" in \
+		arm-*abihf) export ac_cv_c_alignment=need ;; \
+	esac; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-extstore \


### PR DESCRIPTION
This fixes our test failures on Debian-based arm32v7, and fixes *most* of our test failures on Alpine-based arm32v{6,7}, leaving the notable `t/restart.t` which we've had issues with prior (https://github.com/memcached/memcached/issues/799).

See also https://github.com/memcached/memcached/issues/1220#issuecomment-2770251664 (and surrounding chatter).