### PR TITLE
Remove Alpine arm32 builds

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -108,6 +108,13 @@ for version; do
 		suiteAliases=( "${suiteAliases[@]//latest-/}" )
 		variantAliases+=( "${suiteAliases[@]}" )
 
+		if [ "$variant" = 'alpine' ]; then
+			# https://github.com/memcached/memcached/issues/799
+			# https://github.com/docker-library/memcached/issues/69
+			arches="$(sed -r -e 's/ arm32v6 / /g' <<<" $arches ")"
+			arches="$(sed -r -e 's/ arm32v7 / /g' <<<" $arches ")"
+		fi
+
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")


### PR DESCRIPTION
This is essentially a partial revert of 9152f806bff0607bbd25bae9e00b55389498e3da (we got the Debian builds passing, so this is now Alpine-only).

See:
- https://github.com/memcached/memcached/issues/799
- https://github.com/docker-library/memcached/issues/69