### PR TITLE
Apply `stop_time` restart patch

### DIFF
--- a/1/alpine/Dockerfile
+++ b/1/alpine/Dockerfile
@@ -60,6 +60,13 @@ RUN set -eux; \
 	patch --input="$PWD/memcached-extstore-test-stability.patch" --strip=1 --directory=/usr/src/memcached; \
 	rm memcached-extstore-test-stability.patch; \
 	\
+# https://github.com/memcached/memcached/issues/799
+# https://github.com/memcached/memcached/pull/1237
+	wget -O memcached-stop_time.patch 'https://github.com/memcached/memcached/commit/37c94672231c471de2d75ff73f46ec9e72f15f44.patch?full_index=1'; \
+	echo '9d33a0c277b406fd79303ff58eab205a3a54ae2b4431ba239fb99a46a1903eff *memcached-stop_time.patch' | sha256sum -c -; \
+	patch --input="$PWD/memcached-stop_time.patch" --strip=1 --directory=/usr/src/memcached; \
+	rm memcached-stop_time.patch; \
+	\
 	cd /usr/src/memcached; \
 	\
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/1/debian/Dockerfile
+++ b/1/debian/Dockerfile
@@ -63,6 +63,13 @@ RUN set -eux; \
 	patch --input="$PWD/memcached-extstore-test-stability.patch" --strip=1 --directory=/usr/src/memcached; \
 	rm memcached-extstore-test-stability.patch; \
 	\
+# https://github.com/memcached/memcached/issues/799
+# https://github.com/memcached/memcached/pull/1237
+	wget -O memcached-stop_time.patch 'https://github.com/memcached/memcached/commit/37c94672231c471de2d75ff73f46ec9e72f15f44.patch?full_index=1'; \
+	echo '9d33a0c277b406fd79303ff58eab205a3a54ae2b4431ba239fb99a46a1903eff *memcached-stop_time.patch' | sha256sum -c -; \
+	patch --input="$PWD/memcached-stop_time.patch" --strip=1 --directory=/usr/src/memcached; \
+	rm memcached-stop_time.patch; \
+	\
 	cd /usr/src/memcached; \
 	\
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -95,6 +95,13 @@ RUN set -eux; \
 	patch --input="$PWD/memcached-extstore-test-stability.patch" --strip=1 --directory=/usr/src/memcached; \
 	rm memcached-extstore-test-stability.patch; \
 	\
+# https://github.com/memcached/memcached/issues/799
+# https://github.com/memcached/memcached/pull/1237
+	wget -O memcached-stop_time.patch 'https://github.com/memcached/memcached/commit/37c94672231c471de2d75ff73f46ec9e72f15f44.patch?full_index=1'; \
+	echo '9d33a0c277b406fd79303ff58eab205a3a54ae2b4431ba239fb99a46a1903eff *memcached-stop_time.patch' | sha256sum -c -; \
+	patch --input="$PWD/memcached-stop_time.patch" --strip=1 --directory=/usr/src/memcached; \
+	rm memcached-stop_time.patch; \
+	\
 {{ ) else "" end -}}
 	cd /usr/src/memcached; \
 	\

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -108,13 +108,6 @@ for version; do
 		suiteAliases=( "${suiteAliases[@]//latest-/}" )
 		variantAliases+=( "${suiteAliases[@]}" )
 
-		if [ "$variant" = 'alpine' ]; then
-			# https://github.com/memcached/memcached/issues/799
-			# https://github.com/docker-library/memcached/issues/69
-			arches="$(sed -r -e 's/ arm32v6 / /g' <<<" $arches ")"
-			arches="$(sed -r -e 's/ arm32v7 / /g' <<<" $arches ")"
-		fi
-
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")


### PR DESCRIPTION
This fixes the arm32 Alpine build/test failures, which are also thus re-enabled here.

See:
- https://github.com/memcached/memcached/pull/1237
- https://github.com/memcached/memcached/issues/799
- https://github.com/memcached/memcached/issues/1220#issuecomment-3109594827

(I've written this such that it's assuming this patch will make it into the next release -- if it doesn't, something like it or a fix for the same issue should, so I'm not too worried about it.)